### PR TITLE
Frame for LogCheckRule with some unit-tests for example.

### DIFF
--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.hegmanns</groupId>
@@ -11,13 +12,13 @@
 	<description>
 		Test-Utilities for easy testing.
 	</description>
-    <url>www.hegmanns.de</url>
+	<url>www.hegmanns.de</url>
 
-    <scm>
-        <url>https://github.com/bhegmanns/fin-business/tree/master/test-utils</url>
-        <developerConnection>scm:git:https://github.com/bhegmanns/fin-business.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
+	<scm>
+		<url>https://github.com/bhegmanns/fin-business/tree/master/test-utils</url>
+		<developerConnection>scm:git:https://github.com/bhegmanns/fin-business.git</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
 
 	<licenses>
 		<license>
@@ -47,7 +48,7 @@
 		<version.hamcrest>1.3</version.hamcrest>
 		<version.mockito>1.9.5</version.mockito>
 		<version.slf4j>1.7.14</version.slf4j>
-        <version.release-plugin>2.5.3</version.release-plugin>
+		<version.release-plugin>2.5.3</version.release-plugin>
 	</properties>
 
 	<build>
@@ -61,15 +62,15 @@
 					<target>${version.java}</target>
 				</configuration>
 			</plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>${version.release-plugin}</version>
-                <configuration>
-                    <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
-                    <pushChanges>true</pushChanges>
-                </configuration>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>${version.release-plugin}</version>
+				<configuration>
+					<arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
+					<pushChanges>true</pushChanges>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>
@@ -88,15 +89,28 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${version.junit}</version>
-			<!--
-				here no test-scope, because her are some
-				additional add-ons for junit-framework
-			  -->
+			<!-- here no test-scope, because her are some additional add-ons for junit-framework -->
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${version.slf4j}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-jdk14</artifactId>
+			<version>1.8.0-alpha2</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>dk.bitcraft</groupId>
+			<artifactId>LogCollector</artifactId>
+			<version>0.9.0</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.fitnesse</groupId>
@@ -114,48 +128,48 @@
 			<version>3.3.2</version>
 		</dependency>
 	</dependencies>
-    <profiles>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <configuration>
-                            <passphrase>${gpg.passphrase}</passphrase>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus snapshot repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Sonatype Nexus release repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-    </distributionManagement>
+	<profiles>
+		<profile>
+			<id>release-sign-artifacts</id>
+			<activation>
+				<property>
+					<name>performRelease</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<configuration>
+							<passphrase>${gpg.passphrase}</passphrase>
+						</configuration>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+	<distributionManagement>
+		<snapshotRepository>
+			<id>sonatype-nexus-snapshots</id>
+			<name>Sonatype Nexus snapshot repository</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		<repository>
+			<id>sonatype-nexus-staging</id>
+			<name>Sonatype Nexus release repository</name>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+		</repository>
+	</distributionManagement>
 </project>

--- a/test-utils/src/main/java/de/hegmanns/test/utils/rules/consoleredirect/ConsoleRedirectRule.java
+++ b/test-utils/src/main/java/de/hegmanns/test/utils/rules/consoleredirect/ConsoleRedirectRule.java
@@ -7,7 +7,6 @@ import java.io.PrintStream;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.mockito.internal.stubbing.answers.Returns;
 
 /**
  * This JUnit-Rule redirects the console-output to this rule-instance.

--- a/test-utils/src/main/java/de/hegmanns/test/utils/rules/logcheck/LogCheckAppender.java
+++ b/test-utils/src/main/java/de/hegmanns/test/utils/rules/logcheck/LogCheckAppender.java
@@ -1,0 +1,23 @@
+package de.hegmanns.test.utils.rules.logcheck;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+
+public class LogCheckAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+	private List<ILoggingEvent> loggingEvents = new ArrayList<>();
+	
+	@Override
+	protected void append(ILoggingEvent eventObject) {
+		loggingEvents.add(eventObject);
+	}
+
+	public void validate(String exptectedMessage) throws AssertionError{
+		if (loggingEvents.stream().filter((l) -> l.getMessage().contains(exptectedMessage)).count() == 0) {
+			throw new AssertionError("Expected message or part '" + exptectedMessage + "' didn't log");
+		}
+	}
+}

--- a/test-utils/src/main/java/de/hegmanns/test/utils/rules/logcheck/LogCheckRule.java
+++ b/test-utils/src/main/java/de/hegmanns/test/utils/rules/logcheck/LogCheckRule.java
@@ -1,0 +1,60 @@
+package de.hegmanns.test.utils.rules.logcheck;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.ValidationException;
+
+import org.hamcrest.MatcherAssert;
+
+import org.junit.Assert;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.ContextBase;
+
+/**
+ * 
+ * @author B. Hegmanns
+ */
+public class LogCheckRule implements TestRule{
+	
+	private LogCheckStatement logCheckStatement;
+	private List<String> expectedMessages = new ArrayList<>();
+
+	@Override
+	public Statement apply(Statement base, Description description) {
+		logCheckStatement = new LogCheckStatement();
+		logCheckStatement.statement = base;
+		
+		return logCheckStatement;
+	}
+
+	/**
+	 * Create a new instance of {@link LogCheckRule}.
+	 * 
+	 * @return the new instance
+	 */
+	public static LogCheckRule instance() {
+		return new LogCheckRule();
+	}
+
+	public void addExpectedLog(String string) {
+		expectedMessages.add(string);
+	}
+
+	private class LogCheckStatement extends Statement{
+
+		private Statement statement;
+		
+		@Override
+		public void evaluate() throws Throwable {
+			statement.evaluate();
+			throw new AssertionError("LogcheckRule isn't implemented yet");
+		}
+		
+	}
+}

--- a/test-utils/src/test/java/de/hegmanns/test/utils/rules/logcheck/AnyTestClass.java
+++ b/test-utils/src/test/java/de/hegmanns/test/utils/rules/logcheck/AnyTestClass.java
@@ -1,0 +1,21 @@
+package de.hegmanns.test.utils.rules.logcheck;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A sample test class with some logging (jdk-logging)
+ * 
+ * @author B. Hegmanns
+ */
+public class AnyTestClass {
+	private static Logger LOG = Logger.getLogger(AnyTestClass.class.getName());
+
+	public void doWhat() {
+		LOG.info("I do what");
+	}
+	
+	public void doAnything() {
+		LOG.log(Level.WARNING, "I do anything");
+	}
+}

--- a/test-utils/src/test/java/de/hegmanns/test/utils/rules/logcheck/LogCheckRuleUnitTest.java
+++ b/test-utils/src/test/java/de/hegmanns/test/utils/rules/logcheck/LogCheckRuleUnitTest.java
@@ -1,0 +1,58 @@
+package de.hegmanns.test.utils.rules.logcheck;
+
+import java.util.logging.Level;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Some example tests, actual more like integration test.
+ * Feel free implementing more and more additional  tests.
+ * 
+ * @author B. Hegmanns
+ */
+public class LogCheckRuleUnitTest {
+	
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Rule
+	public LogCheckRule logCheckRule = LogCheckRule.instance();
+
+	private AnyTestClass anyTestClassInstance = new AnyTestClass();
+	
+	/**
+	 * Test for logging with SLF4J-Logger.
+	 */
+	@Test
+	public void checkLogWithSlf4j() {
+		logCheckRule.addExpectedLog("Hello");
+		
+		Logger logger = LoggerFactory.getLogger(LogCheckRuleUnitTest.class);
+		logger.info("Hello");
+	}
+
+	/**
+	 * Test for JDK-Logger (java.util.logging) 
+	 */
+	@Test
+	public void checkLogWithJdkLogging() {
+		logCheckRule.addExpectedLog("Hello");
+		
+		java.util.logging.Logger logger = java.util.logging.Logger.getLogger(LogCheckRuleUnitTest.class.getName());
+		logger.log(Level.INFO, "Hello");
+	}
+	
+	/**
+	 * Test for missing the expected log.
+	 */
+	@Test
+	public void noLog() {
+		exception.expect(AssertionError.class);
+		logCheckRule.addExpectedLog("I do what");
+	}
+}


### PR DESCRIPTION
Delete a wrong import in ConsoleRedirectRule.

The build fails, because all tests in LogCheckRuleUnitTest fail.