### PR TITLE
add unit test for SerializationTestHelper class

### DIFF
--- a/test-utils/src/main/java/de/hegmanns/test/utils/SerializationTestHelper.java
+++ b/test-utils/src/main/java/de/hegmanns/test/utils/SerializationTestHelper.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.io.NotSerializableException;
+import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
@@ -41,13 +42,13 @@ public class SerializationTestHelper {
 	 * Note, that the instance/class have to implement {@link Serializable}-interface.
 	 * 
 	 * @param instance the (serializable) instance
-	 * @param outputStream the output stream where the object would be written
+	 * @param objectOutput the output stream where the object would be written
 	 * @return {@link SerialationTestResult#OK} is it works other see {@link SerialationTestResult}
 	 */
-	public static SerialationTestResult serializeIntoStream(Object instance, ObjectOutputStream outputStream){
+	public static SerialationTestResult serializeIntoStream(Object instance, ObjectOutput objectOutput){
 		SerialationTestResult result = SerialationTestResult.OK;
 		try {
-			outputStream.writeObject(instance);
+			objectOutput.writeObject(instance);
 		} 
 		catch(InvalidClassException e){
 			result = SerialationTestResult.ERROR_INVALID_CLASS;

--- a/test-utils/src/test/java/de/hegmanns/test/utils/rules/SerializationTestHelperUnitTest.java
+++ b/test-utils/src/test/java/de/hegmanns/test/utils/rules/SerializationTestHelperUnitTest.java
@@ -1,0 +1,65 @@
+package de.hegmanns.test.utils.rules;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.NotSerializableException;
+import java.io.ObjectOutput;
+
+import static de.hegmanns.test.utils.SerializationTestHelper.SerialationTestResult.ERROR_INVALID_CLASS;
+import static de.hegmanns.test.utils.SerializationTestHelper.SerialationTestResult.ERROR_IO;
+import static de.hegmanns.test.utils.SerializationTestHelper.SerialationTestResult.ERROR_NOT_SERIALIZABLE;
+import static de.hegmanns.test.utils.SerializationTestHelper.SerialationTestResult.OK;
+import static de.hegmanns.test.utils.SerializationTestHelper.serializeIntoStream;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Created by cwancowicz on 10/13/17.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SerializationTestHelperUnitTest {
+
+    @Mock
+    private ObjectOutput objectOutput;
+
+    @Test
+    public void shouldWriteObjectWhenSerializeIntoStream() throws IOException {
+        Object object = new Object();
+        serializeIntoStream(object, objectOutput);
+
+        verify(objectOutput).writeObject(object);
+    }
+
+    @Test
+    public void shouldReturnOkWhenSerializeIntoStreamSuccessfully() {
+        assertEquals(OK, serializeIntoStream(new Object(), objectOutput));
+    }
+
+    @Test
+    public void shouldReturnInvalidClassWhenSerializingIntoStream() throws IOException {
+        doThrow(new InvalidClassException("testing")).when(objectOutput).writeObject(any());
+
+        assertEquals(ERROR_INVALID_CLASS, serializeIntoStream(new Object(), objectOutput));
+    }
+
+    @Test
+    public void shouldReturnNotSerializableWhenSerializingIntoStream() throws IOException {
+        doThrow(new NotSerializableException("testing")).when(objectOutput).writeObject(any());
+
+        assertEquals(ERROR_NOT_SERIALIZABLE, serializeIntoStream(new Object(), objectOutput));
+    }
+
+    @Test
+    public void shouldReturnIOErrorWhenSerializingIntoStream() throws IOException {
+        doThrow(new IOException("testing")).when(objectOutput).writeObject(any());
+
+        assertEquals(ERROR_IO, serializeIntoStream(new Object(), objectOutput));
+    }
+}


### PR DESCRIPTION
I modified the method signature of SerializationTestHelper.serializeIntoStream to accept the ObjectOutput interface. This allowed easier mocking since the writeObject method is final (couldn't get PowerMockito to mock the final method after many attempts). This is also a little more cleaner in my opinion too.

Also - would it be better to change Object instance to Serializable instance ? I noticed in the javadoc comment "Note, that the instance/class have to implement {@link Serializable}-interface." seems like changing it from Object -> Serializable would make more sense if thats a requirement.